### PR TITLE
Housekeeping

### DIFF
--- a/src/client/Gui.lua
+++ b/src/client/Gui.lua
@@ -41,15 +41,15 @@ function Gui.Init()
     Gui.Orbcam = false
     Gui.CameraTween = nil
 
-    listenButton = listenerGui.ListenButton
-    detachButton = listenerGui.DetachButton
-    detachSpeakerButton = speakerGui.DetachButton
-    returnButton = listenerGui.ReturnButton
-    peekButton = listenerGui.PeekButton
-    viewportFrame = listenerGui.ViewportFrame
-    speakerViewportFrame = speakerGui.ViewportFrame
-    returnButtonSpeaker = speakerGui.ReturnButton
-    peekButtonSpeaker = speakerGui.PeekButton
+    listenButton = listenerGui:WaitForChild("ListenButton")
+    detachButton = listenerGui:WaitForChild("DetachButton")
+    detachSpeakerButton = speakerGui:WaitForChild("DetachButton")
+    returnButton = listenerGui:WaitForChild("ReturnButton")
+    peekButton = listenerGui:WaitForChild("PeekButton")
+    viewportFrame = listenerGui:WaitForChild("ViewportFrame")
+    speakerViewportFrame = speakerGui:WaitForChild("ViewportFrame")
+    returnButtonSpeaker = speakerGui:WaitForChild("ReturnButton")
+    peekButtonSpeaker = speakerGui:WaitForChild("PeekButton")
 
     -- 
     -- Listening
@@ -253,7 +253,7 @@ function Gui.PointOfInterest()
     if Gui.Orb == nil then return end
 
     local boards = CollectionService:GetTagged("metaboard")
-    local pois = CollectionService:GetTagged("metaorb_poi")
+    local pois = CollectionService:GetTagged(Config.PointOfInterestTag)
 
     if #boards == 0 and #pois == 0 then return nil end
 
@@ -308,7 +308,7 @@ function Gui.PopulateViewport()
 	
     local orbCameraPos = Vector3.new(Gui.Orb.Position.X, poiPosition.Y, Gui.Orb.Position.Z)
 
-	viewportCamera.CFrame = CFrame.new( orbCameraPos, poiPosition )
+	viewportCamera.CFrame = CFrame.lookAt(orbCameraPos, poiPosition)
 end
 
 function Gui.ListenOn()
@@ -473,7 +473,7 @@ function Gui.OrbcamTweeningStart(newPos, poiPos)
     local orbCameraPos = Vector3.new(newPos.X, poiPos.Y, newPos.Z)
 
     Gui.CameraTween = TweenService:Create(camera, tweenInfo, 
-        {CFrame = CFrame.new(orbCameraPos, poiPos)})
+        {CFrame = CFrame.lookAt(orbCameraPos, poiPos)})
 
     Gui.CameraTween:Play()
 end
@@ -491,7 +491,7 @@ function Gui.OrbcamOn(guiOff)
 	end
 	
     local orbCameraPos = Vector3.new(Gui.Orb.Position.X, poiPos.Y, Gui.Orb.Position.Z)
-	camera.CFrame = CFrame.new(orbCameraPos,poiPos)
+	camera.CFrame = CFrame.lookAt(orbCameraPos, poiPos)
     
     if guiOff then
         speakerGui.Enabled = false

--- a/src/server/Orb.lua
+++ b/src/server/Orb.lua
@@ -20,7 +20,6 @@ local speakerAttachSoundIds = { 7873470625, 7873470425,
 local speakerDetachSoundId = 7864770869
 
 local Orb = {}
-Orb.__index = Orb
 
 function Orb.Init()
 	-- Offset of ghosts from orbs (playedID -> Vector3)
@@ -90,7 +89,7 @@ function Orb.Init()
 			targetCFrame = CFrame.new(orb.Position + Vector3.new(0,5 * orb.Size.Y,0))
 		end
 
-		plr.Character.PrimaryPart.CFrame = targetCFrame
+		plr.Character:PivotTo(targetCFrame)
 	end)
 
 	-- Remove leaving players as listeners and speakers
@@ -145,7 +144,7 @@ function Orb.InitOrb(orb)
 	waypoint.Transparency = 1
 	waypoint.Anchored = true
 	waypoint.CanCollide = false
-	CollectionService:AddTag(waypoint, "metaorb_waypoint")
+	CollectionService:AddTag(waypoint, Config.WaypointTag)
 	waypoint.Parent = orb
 
 	-- Sound to announce speaker attachment
@@ -261,9 +260,9 @@ function Orb.RotateGhostToFaceSpeaker(orb, ghost)
 		0 -- DelayTime
 	)
 
-	local ghostTween = TweenService:Create(ghost.PrimaryPart, tweenInfo, 
-		{CFrame = CFrame.new(ghostPos,speakerPosXZ)})
-	
+	local ghostTween = TweenService:Create(ghost.PrimaryPart, tweenInfo,
+		{CFrame = CFrame.lookAt(ghostPos, speakerPosXZ)})
+
 	ghostTween:Play()
 end
 
@@ -306,7 +305,7 @@ function Orb.WalkGhosts(orb, pos)
 				if not reached then
 					local speakerPos = Orb.GetSpeakerPosition(orb)
 					if speakerPos ~= nil then
-						ghost.PrimaryPart.CFrame = CFrame.new(newPos, speakerPos)
+						ghost:PivotTo(CFrame.lookAt(newPos, speakerPos))
 					else
 						ghost.PrimaryPart.Position = newPos
 					end
@@ -369,7 +368,7 @@ function Orb.TweenOrbToNearPosition(orb, pos)
 		local orbTween
 		if poiPos ~= nil then
 			orbTween = TweenService:Create(orb, tweenInfo, 
-				{CFrame = CFrame.new(minWaypoint.Position, poiPos)})
+				{CFrame = CFrame.lookAt(minWaypoint.Position, poiPos)})
 		else
 			orbTween = TweenService:Create(orb, tweenInfo, 
 				{Position = minWaypoint.Position})
@@ -412,9 +411,9 @@ function Orb.AddGhost(orb, playerId)
 		local speakerPos = Orb.GetSpeakerPosition(orb)
 		if speakerPos then
 			local speakerPosXZ = Vector3.new(speakerPos.X,ghostPos.Y,speakerPos.Z)
-			ghost:SetPrimaryPartCFrame(CFrame.new(ghostPos,speakerPosXZ))
+			ghost:PivotTo(CFrame.lookAt(ghostPos, speakerPosXZ))
 		else
-			ghost:SetPrimaryPartCFrame(CFrame.new(ghostPos, character.PrimaryPart.Position))
+			ghost:PivotTo(CFrame.lookAt(ghostPos, character.PrimaryPart.Position))
 		end
 
 		for _, desc in ipairs(ghost:GetDescendants()) do
@@ -516,7 +515,7 @@ end
 -- a BasePart or a Model with non-nil PrimaryPart
 function Orb.PointOfInterest(targetPos)
     local boards = CollectionService:GetTagged("metaboard")
-    local pois = CollectionService:GetTagged("metaorb_poi")
+    local pois = CollectionService:GetTagged(Config.PointOfInterestTag)
 
     if #boards == 0 and #pois == 0 then return nil end
 


### PR DESCRIPTION
- Use CFrame.lookAt(from, to) instead of CFrame.new(from, to) because it is more descriptive.
- Use Model:PivotTo() instead of Model.PrimaryPart.CFrame, which has a number of benefits described [here](https://devforum.roblox.com/t/pivot-editor-full-release/1403027).
> :PivotTo() uses the BulkMoveTo infrastructure and some other internal optimizations, so it has better performance than the other methods.
:PivotTo() preserves part and model offsets, so you will not experience floating point drift when using it to repeatedly move an object!
- Call WaitForChild on gui children